### PR TITLE
Specify the prefix to route.

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -74,7 +74,6 @@ $query = '';
  *
  * Else, we print the installation page.
  */
-
 if (false !== $pos = strpos($url, '?')) {
 
     $response->addHeader('Content-Type', 'application/json');
@@ -231,7 +230,7 @@ if (false !== $pos = strpos($url, '?')) {
         );
 
     $query = substr($url, $pos + 1);
-    $router->route($query);
+    $router->route($query, '/');
 
     $dispatcher = new Dispatcher\Basic();
     $dispatcher->dispatch($router);


### PR DESCRIPTION
With Apache, the prefix is not correctly populated if we don't any URL rewriting.

Fix #79.
