### PR TITLE
Support EventSource in Internet Explorer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
     "semantic-ui": "~1.11",
     "ember": "~1.11",
     "ember-data": "~1.0.0-beta.16",
-    "ember-simple-auth": "~0.7.3"
+    "ember-simple-auth": "~0.7.3",
+    "event-source-polyfill": "~0.0.4"
   }
 }

--- a/views/install.html
+++ b/views/install.html
@@ -265,6 +265,7 @@
 <script src="static/vendor/ember/ember.min.js"></script>
 <script src="static/vendor/ember/ember-template-compiler.js"></script>
 <script src="static/vendor/ember-data/ember-data.min.js"></script>
+<script src="static/vendor/event-source-polyfill/eventsource.min.js"></script>
 <script src="static/javascript/install.js"></script>
 
 </body>


### PR DESCRIPTION
EventSource is not supported in IE at all. With this polyfill, it works in IE10+.

Address #135.
