### PR TITLE
Hard delete a principal

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -51,10 +51,8 @@ $autoloadFile =
    'autoload.php';
 
 if (false === file_exists($autoloadFile)) {
-
     echo 'Autoloader is not found. Did you run `composer install`?', "\n";
-    return;
-
+    exit(1);
 }
 
 $autoloader = require_once $autoloadFile;

--- a/lib/DavAcl/Principal/Backend.php
+++ b/lib/DavAcl/Principal/Backend.php
@@ -38,6 +38,7 @@ class Backend extends SabreDavAcl\PrincipalBackend\PDO
     /**
      * Delete the current node.
      *
+     * @param  string  $path    Path (`principals/…`).
      * @return void
      */
     public function deletePrincipal($path)
@@ -53,10 +54,56 @@ class Backend extends SabreDavAcl\PrincipalBackend\PDO
             );
         }
 
-        $statement = $this->pdo->prepare(
-            'DELETE FROM ' . $this->tableName . ' WHERE uri = :uri'
-        );
+        $uri = $path;
 
-        return $statement->execute(['uri' => $path]);
+        $statement = $this->pdo->prepare(
+            'DELETE FROM calendarobjects ' .
+            'WHERE calendarid IN ( ' .
+            '    SELECT id FROM calendars WHERE principaluri = :uri ' .
+            ')'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        $statement = $this->pdo->prepare(
+            'DELETE FROM calendarchanges ' .
+            'WHERE calendarid IN ( ' .
+            '    SELECT id FROM calendars WHERE principaluri = :uri ' .
+            ')'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        $statement = $this->pdo->prepare(
+            'DELETE FROM calendarsubscriptions ' .
+            'WHERE principaluri = :uri'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        $statement = $this->pdo->prepare(
+            'DELETE FROM schedulingobjects ' .
+            'WHERE principaluri = :uri'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        $statement = $this->pdo->prepare(
+            'DELETE FROM calendars ' .
+            'WHERE principaluri = :uri'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        $statement = $this->pdo->prepare(
+            'DELETE FROM groupmembers ' .
+            'WHERE principal_id IN ( ' .
+            '    SELECT id FROM principals WHERE uri = :uri ' .
+            ')'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        $statement = $this->pdo->prepare(
+            'DELETE FROM principals ' .
+            'WHERE uri = :uri'
+        );
+        $statement->execute(['uri' => $uri]);
+
+        return;
     }
 }


### PR DESCRIPTION
Fix #155.

Before we were soft deleting a principal, i.e. only its principal and user data, but the calendars & co. data. We don't have a purge tool, so we hard delete a principal for now.