### PR TITLE
Check version in the administration interface

### DIFF
--- a/lib/Dav/Version/Node.php
+++ b/lib/Dav/Version/Node.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @license
+ *
+ * sabre/katana.
+ * Copyright (C) 2015 fruux GmbH (https://fruux.com/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Sabre\Katana\Dav\Version;
+
+use Sabre\DAV as SabreDav;
+
+/**
+ * The versions node.
+ *
+ * @copyright Copyright (C) 2015 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license GNU Affero General Public License, Version 3.
+ */
+class Node extends SabreDav\Node
+{
+    /**
+     * Get the node's name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'versions';
+    }
+}

--- a/lib/Dav/Version/Node.php
+++ b/lib/Dav/Version/Node.php
@@ -34,12 +34,19 @@ use Sabre\DAV as SabreDav;
 class Node extends SabreDav\Node
 {
     /**
+     * Define the node name.
+     *
+     * @const string
+     */
+    const NAME = 'versions';
+
+    /**
      * Get the node's name.
      *
      * @return string
      */
     public function getName()
     {
-        return 'versions';
+        return self::NAME;
     }
 }

--- a/lib/Dav/Version/Plugin.php
+++ b/lib/Dav/Version/Plugin.php
@@ -70,8 +70,22 @@ class Plugin extends SabreDav\ServerPlugin
         ];
     }
 
+    /**
+     * Use this method to tell the server this plugin defines additional
+     * HTTP methods.
+     *
+     * This method is passed a URI. It should only return HTTP methods that are
+     * available for the specified URI.
+     *
+     * @param  string $path
+     * @return array
+     */
     public function getHTTPMethods($path)
     {
+        if (Node::NAME !== $path) {
+            return [];
+        }
+
         return ['GET'];
     }
 
@@ -99,7 +113,7 @@ class Plugin extends SabreDav\ServerPlugin
      */
     public function httpGet(Request $request, Response $response)
     {
-        if ('versions' !== $request->getPath()) {
+        if (Node::NAME !== $request->getPath()) {
             return;
         }
 

--- a/lib/Dav/Version/Plugin.php
+++ b/lib/Dav/Version/Plugin.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * @license
+ *
+ * sabre/katana.
+ * Copyright (C) 2015 fruux GmbH (https://fruux.com/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Sabre\Katana\Dav\Version;
+
+use Sabre\Katana\Server\Updater;
+use Sabre\DAV as SabreDav;
+use Sabre\HTTP\RequestInterface as Request;
+use Sabre\HTTP\ResponseInterface as Response;
+
+/**
+ * The version plugin is responsible to get current version and check if a new
+ * version exists.
+ *
+ * @copyright Copyright (C) 2015 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license GNU Affero General Public License, Version 3.
+ */
+class Plugin extends SabreDav\ServerPlugin
+{
+    /**
+     * Returns a plugin name.
+     *
+     * Using this name other plugins will be able to access other plugins
+     * using \Sabre\DAV\Server::getPlugin
+     *
+     * @return string
+     */
+    public function getPluginName()
+    {
+        return 'version';
+    }
+
+    /**
+     * Returns a bunch of meta-data about the plugin.
+     *
+     * Providing this information is optional, and is mainly displayed by the
+     * Browser plugin.
+     *
+     * The description key in the returned array may contain html and will not
+     * be sanitized.
+     *
+     * @return array
+     */
+    public function getPluginInfo()
+    {
+        return [
+            'name'        => $this->getPluginName(),
+            'description' => 'Get current version and check if a new one exists.',
+            'link'        => 'http://sabre.io/katana/'
+        ];
+    }
+
+    public function getHTTPMethods($path)
+    {
+        return ['GET'];
+    }
+
+    /**
+     * This initializes the plugin.
+     *
+     * This function is called by Sabre\DAV\Server, after
+     * addPlugin is called.
+     *
+     * This method should set up the required event subscriptions.
+     *
+     * @param  SabreDav\Server $server    Server.
+     * @return void
+     */
+    public function initialize(SabreDav\Server $server)
+    {
+        $server->on('method:GET', [$this, 'httpGet']);
+
+        return;
+    }
+
+    /**
+     *
+     * @return boolean
+     */
+    public function httpGet(Request $request, Response $response)
+    {
+        if ('versions' !== $request->getPath()) {
+            return;
+        }
+
+        $payload = [
+            'current_version' => SABRE_KATANA_VERSION
+        ];
+
+        $updatesDotJson = Updater::getUpdateUrl();
+        $versions       = @file_get_contents($updatesDotJson);
+
+        if (!empty($versions)) {
+            $versions        = json_decode($versions, true);
+            $versionsToFetch = Updater::filterVersions(
+                $versions,
+                SABRE_KATANA_VERSION,
+                Updater::FORMAT_PHAR
+            );
+            $payload['next_versions'] = array_keys($versionsToFetch);
+        }
+
+        $response->setHeader('Content-Type', 'application/json');
+        $response->setBody(json_encode($payload));
+
+        return false;
+    }
+}

--- a/lib/Dav/Version/Plugin.php
+++ b/lib/Dav/Version/Plugin.php
@@ -107,8 +107,17 @@ class Plugin extends SabreDav\ServerPlugin
             'current_version' => SABRE_KATANA_VERSION
         ];
 
-        $updatesDotJson = Updater::getUpdateUrl();
-        $versions       = @file_get_contents($updatesDotJson);
+        $extra = [];
+
+        if (true === $request->hasHeader('Referer')) {
+            $extra['referer'] = $request->getHeader('Referer');
+        }
+
+        $updatesDotJson = Updater::getUpdateUrl(
+            Updater::DEFAULT_UPDATE_SERVER,
+            $extra
+        );
+        $versions = @file_get_contents($updatesDotJson);
 
         if (!empty($versions)) {
             $versions        = json_decode($versions, true);

--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -100,7 +100,8 @@ class Server
      *    * CalDAV,
      *    * CardDAV,
      *    * ACL,
-     *    * synchronization.
+     *    * synchronization,
+     *    * versions.
      *
      * @return void
      */
@@ -115,6 +116,7 @@ class Server
         $this->initializeCardDAV($principalBackend);
         $this->initializeACL();
         $this->initializeSynchronization();
+        $this->initializeVersions();
 
         return;
     }
@@ -257,6 +259,19 @@ class Server
     protected function initializeSynchronization()
     {
         $this->getServer()->addPlugin(new SabreDav\Sync\Plugin());
+
+        return;
+    }
+
+    /**
+     * Initialize versions.
+     *
+     * @return void
+     */
+    protected function initializeVersions()
+    {
+        $this->getServer()->tree->getNodeForPath('')->addChild(new Dav\Version\Node());
+        $this->getServer()->addPlugin(new Dav\Version\Plugin());
 
         return;
     }

--- a/lib/Server/Updater.php
+++ b/lib/Server/Updater.php
@@ -96,7 +96,7 @@ class Updater
      *         …
      *     ]
      *
-     * @param  array  $versions    List of versions.
+     * @param  array   $versions          List of versions.
      * @param  string  $currentVersion    Current version, i.e. lowest version
      *                                    to keep.
      * @param  int     $format            Please, see `FORMAT_*` constant.

--- a/lib/Server/Updater.php
+++ b/lib/Server/Updater.php
@@ -58,19 +58,20 @@ class Updater
      * Get the URL of the `updates.json` file, containing the list of updates.
      *
      * @param  string  $updateServer    Update server URL.
+     * @param  array   $queries         Extra queries to add.
      * @return string
      */
-    public static function getUpdateUrl($updateServer = null)
+    public static function getUpdateUrl($updateServer = null, array $queries = [])
     {
         if (null === $updateServer) {
             $updateServer = static::DEFAULT_UPDATE_SERVER;
         }
 
-        return sprintf(
-            '%supdates.json?version=%s',
-            $updateServer,
-            SABRE_KATANA_VERSION
-        );
+        $out                 = $updateServer . 'updates.json';
+        $queries['version']  = SABRE_KATANA_VERSION;
+        $out                .= '?' . http_build_query($queries, '', '&', PHP_QUERY_RFC3986);
+
+        return $out;
     }
 
     /**

--- a/public/static/css/ui.css
+++ b/public/static/css/ui.css
@@ -1,3 +1,4 @@
+
 body {
     position: relative;
     background: radial-gradient(circle at 100% 0%, #efd6c9, #d8b4a2);
@@ -21,9 +22,9 @@ body::before {
     transition: opacity .4s ease;
 }
 
-html:not(.logged) > body::before {
-    opacity: 1;
-}
+    html:not(.logged) > body::before {
+        opacity: 1;
+    }
 
 header > h1 > img {
     width: 100px !important;
@@ -31,4 +32,10 @@ header > h1 > img {
 
 .segment {
     background: rgba(255, 255, 255, .85) !important;
+    transition: opacity .3s ease;
 }
+
+    html.modal .segment:not(.modal-exclusive) {
+        pointer-events: none;
+        opacity: .3;
+    }

--- a/public/static/javascript/admin.js
+++ b/public/static/javascript/admin.js
@@ -247,28 +247,33 @@ Katana.ApplicationController = Ember.Controller.extend(SimpleAuth.Authentication
     /**
      * Whether the login form is valid or not.
      */
-    valid            : true,
+    valid              : true,
 
     /**
      * Whether the login form is submitting or not.
      */
-    submitting       : false,
+    submitting         : false,
 
     /**
      * Tick for the session activity. Does not contain any useful information.
      * Only allows to react to an event (tick update).
      */
-    lastSessionTick  : null,
+    lastSessionTick    : null,
 
     /**
      * Number of seconds before the session expires.
      */
-    sessionExpireIn  : 0,
+    sessionExpireIn    : 0,
 
     /**
      * Whether the session is about to expire or not.
      */
-    sessionWillExpire: false,
+    sessionWillExpire  : false,
+
+    /**
+     * Whether a new version of sabre/katana is available.
+     */
+    newVersionAvailable: false,
 
     /**
      * Current alert title and message.
@@ -322,6 +327,20 @@ Katana.ApplicationController = Ember.Controller.extend(SimpleAuth.Authentication
             1000
         );
     }.observes('lastSessionTick').on('init'),
+
+    /**
+     * Check if a new version of sabre/katana is available or not.
+     */
+    checkVersion: function()
+    {
+        var self = this;
+
+        $.getJSON(ENV.katana.base_url + '/versions').then(
+            function(data) {
+                self.set('newVersionAvailable', undefined !== data.next_versions);
+            }
+        );
+    }.observes('session.isAuthenticated'),
 
     actions: {
 
@@ -390,6 +409,15 @@ Katana.ApplicationView = Ember.View.extend({
                         onApprove: function() {
                             return false;
                         }
+                    }
+                );
+
+                // Dismiss message.
+                $('body').on(
+                    'click',
+                    '.message .close',
+                    function() {
+                        $(this).closest('.message').remove();
                     }
                 );
             }

--- a/tests/Unit/Server/Updater.php
+++ b/tests/Unit/Server/Updater.php
@@ -43,11 +43,9 @@ class Updater extends Suite
             ->then
                 ->string($result)
                     ->isEqualTo(
-                        sprintf(
-                            '%supdates.json?version=%s',
-                            CUT::DEFAULT_UPDATE_SERVER,
-                            SABRE_KATANA_VERSION
-                        )
+                        CUT::DEFAULT_UPDATE_SERVER .
+                        'updates.json?' .
+                        'version=' . SABRE_KATANA_VERSION
                     );
     }
 
@@ -59,11 +57,25 @@ class Updater extends Suite
             ->then
                 ->string($result)
                     ->isEqualTo(
-                        sprintf(
-                            '%supdates.json?version=%s',
-                            $server,
-                            SABRE_KATANA_VERSION
-                        )
+                        $server .
+                        'updates.json?' .
+                        'version=' . SABRE_KATANA_VERSION
+                    );
+    }
+
+    public function case_get_list_of_updates_url_extra_queries()
+    {
+        $this
+            ->given($queries = ['a' => 'b c', 'd' => 'e'])
+            ->when($result = CUT::getUpdateUrl(CUT::DEFAULT_UPDATE_SERVER, $queries))
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        CUT::DEFAULT_UPDATE_SERVER .
+                        'updates.json?' .
+                        'a=b%20c&' .
+                        'd=e&' .
+                        'version=' . SABRE_KATANA_VERSION
                     );
     }
 

--- a/views/admin.html
+++ b/views/admin.html
@@ -43,6 +43,20 @@
     {{/if}}
 
     {{#if session.isAuthenticated}}
+      {{#if newVersionAvailable}}
+        <div class="ui icon info message">
+          <i class="close icon"></i>
+          <i class="announcement icon"></i>
+          <div class="content">
+            <div class="header">A new version is available!</div>
+            <p>Your instance of sabre/katana is outdated. A new version is
+            available. To update sabre/katana, please check
+            <a href="https://github.com/fruux/sabre-katana/#update">the
+            documentation</a>.</p>
+          </div>
+        </div>
+      {{/if}}
+
       <nav class="ui segment menu">
         {{#link-to 'users' class="item"}}
           <i class="users icon"></i> Users

--- a/views/admin.html
+++ b/views/admin.html
@@ -14,17 +14,6 @@
   <link rel="stylesheet" href="static/vendor/semantic-ui/dist/semantic.min.css" type="text/css" />
   <link rel="stylesheet" href="static/css/layout.css" type="text/css" />
   <link rel="stylesheet" href="static/css/ui.css" type="text/css" />
-
-  <style>
-    .segment {
-        transition: opacity .2s ease;
-    }
-
-    html.modal .segment:not(.modal-exclusive) {
-        pointer-events: none;
-        opacity: .3;
-    }
-  </style>
 </head>
 <body>
 


### PR DESCRIPTION
From the server-side: We introduce a new node, called `/versions`, that returns a JSON payload of kind

    {"current_version": …}

if no new version exists, or of kind

    {"current_version": …, "next_versions": […]}

if new versions exist.

From the client-side: We send a `GET` request on this new node and check the `next_versions` property. If new versions exists, we prompt a (dissmissable) message to the user saying that a new version is available.