### PR TITLE
Only the administrator can log

### DIFF
--- a/lib/Dav/Version/Node.php
+++ b/lib/Dav/Version/Node.php
@@ -23,6 +23,7 @@
 namespace Sabre\Katana\Dav\Version;
 
 use Sabre\DAV as SabreDav;
+use Sabre\DAVACL as SabreDavAcl;
 
 /**
  * The versions node.
@@ -31,7 +32,7 @@ use Sabre\DAV as SabreDav;
  * @author Ivan Enderlin
  * @license GNU Affero General Public License, Version 3.
  */
-class Node extends SabreDav\Node {
+class Node extends SabreDav\Node implements SabreDavAcl\IACL {
     /**
      * Define the node name.
      *
@@ -45,6 +46,86 @@ class Node extends SabreDav\Node {
      * @return string
      */
     function getName() {
+
         return self::NAME;
+    }
+
+    /**
+     * Get the owner principal
+     *
+     * This must be a url to a principal, or null if there's no owner.
+     *
+     * @return string|null
+     */
+    function getOwner() {
+
+        return 'principals/admin';
+    }
+
+    /**
+     * Get a group principal
+     *
+     * This must be a URL to a principal, or null if there's no owner.
+     *
+     * @return string|null
+     */
+    function getGroup() {
+
+        return null;
+    }
+
+    /**
+     * Get a list of ACE's for this node.
+     *
+     * Each ACE has the following properties:
+     *   * 'privilege', a string such as {DAV:}read or {DAV:}write. These are
+     *     currently the only supported privileges
+     *   * 'principal', a url to the principal who owns the node
+     *   * 'protected' (optional), indicating that this ACE is not allowed to
+     *      be updated.
+     *
+     * @return array
+     */
+    function getACL() {
+
+        return [
+            [
+                'principal' => $this->getOwner(),
+                'privilege' => '{DAV:}read',
+                'protected' => true
+            ]
+        ];
+    }
+
+    /**
+     * Updates the ACL.
+     *
+     * This method will receive a list of new ACE's as an array argument.
+     *
+     * @param array $acl
+     * @return void
+     */
+    function setACL(array $acl) {
+
+        throw new SabreDav\Exception\Forbidden(
+            'Updating ACLs it not allowed on this node.'
+        );
+    }
+
+    /**
+     * Get the list of supported privileges for this node.
+     *
+     * The returned data structure is a list of nested privileges.
+     * See Sabre\DAVACL\Plugin::getDefaultSupportedPrivilegeSet for a simple
+     * standard structure.
+     *
+     * If null is returned from this method, the default privilege set is used,
+     * which is fine for most common usecases.
+     *
+     * @return array|null
+     */
+    function getSupportedPrivilegeSet() {
+
+        return null;
     }
 }

--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -82,6 +82,7 @@ class Server {
      * @return void
      */
     function __construct() {
+
         $this->initialize();
     }
 
@@ -122,6 +123,7 @@ class Server {
      * @return void
      */
     protected function initializeConfiguration() {
+
         $this->configuration = new Configuration(static::CONFIGURATION_FILE);
     }
 
@@ -146,6 +148,7 @@ class Server {
      * @return void
      */
     protected function initializeServer() {
+
         $this->server = new SabreDav\Server(null);
         $this->server->setBaseUri(
             $this->getConfiguration()->base_url ?: '/'
@@ -159,6 +162,7 @@ class Server {
      * @return void
      */
     protected function initializeAuthentication() {
+
         $database = $this->getDatabase();
         $backend  = new Dav\Authentication\BasicBackend($database);
         $plugin   = new SabreDav\Auth\Plugin($backend);
@@ -172,6 +176,7 @@ class Server {
      * @return void
      */
     protected function initializePrincipals(DavAcl\Principal\Backend &$backend = null) {
+
         if (null === $backend) {
             $backend = new DavAcl\Principal\Backend($this->getDatabase());
         }
@@ -188,6 +193,7 @@ class Server {
      * @return void
      */
     protected function initializeCalDAV(DavAcl\Principal\Backend $principalBackend) {
+
         $backend = new SabreCalDav\Backend\PDO($this->getDatabase());
         $node    = new SabreCalDav\CalendarRoot($principalBackend, $backend);
         $this->getServer()->tree->getNodeForPath('')->addChild($node);
@@ -216,6 +222,7 @@ class Server {
      * @return void
      */
     protected function initializeACL() {
+
         $plugin                               = new SabreDavAcl\Plugin();
         $plugin->adminPrincipals[]            = 'principals/' . static::ADMINISTRATOR_LOGIN;
         $plugin->allowAccessToNodesWithoutACL = true;
@@ -231,6 +238,7 @@ class Server {
      * @return void
      */
     protected function initializeSynchronization() {
+
         $this->getServer()->addPlugin(new SabreDav\Sync\Plugin());
     }
 
@@ -239,12 +247,10 @@ class Server {
      *
      * @return void
      */
-    protected function initializeVersions()
-    {
+    protected function initializeVersions() {
+
         $this->getServer()->tree->getNodeForPath('')->addChild(new Dav\Version\Node());
         $this->getServer()->addPlugin(new Dav\Version\Plugin());
-
-        return;
     }
 
     /**


### PR DESCRIPTION
First, we protect the `/versions` node from being read by anyone. Only `principal/admin` can read it.

Second, we use a node only accessible by an administrator (`/versions`) to check that this is actually an administrator that tries to connect.

This is not the best solution, but it works. I will open a new issue to discuss about a better “admin” architecture soon.