### PR TITLE
Fix `node.children` on Safari

### DIFF
--- a/public/static/javascript/katana-webdav-adapter.js
+++ b/public/static/javascript/katana-webdav-adapter.js
@@ -636,8 +636,10 @@ var KatanaWebDAVParser = {
         var children = [];
         var child    = null;
 
-        for (var i = 0; i < node.children.length; ++i) {
-            children.push(this.xmlToPrimitive(node.children[i]));
+        for (var i = 0; i < node.childNodes.length; ++i) {
+            if (node.ELEMENT_NODE === node.childNodes[i].nodeType) {
+                children.push(this.xmlToPrimitive(node.childNodes[i]));
+            }
         }
 
         if (0 === children.length) {


### PR DESCRIPTION
Fix #196.

`node.children` does not exist in Safari. We use `childNodes` and filter by `ELEMENT_NODE` type.