### PR TITLE
Fix calendar type in upper case and lower case

### DIFF
--- a/public/static/javascript/katana-webdav-adapter.js
+++ b/public/static/javascript/katana-webdav-adapter.js
@@ -502,7 +502,8 @@ var KatanaCalDAVAdapter = DS.Adapter.extend({
     findQuery: function(store, type, query, recordArray)
     {
         var username = query.username;
-        var type     = (query.type || 'vevent').toUpperCase();
+        var type     = (query.type || 'vevent');
+        var TYPE     = type.toUpperCase();
 
         if (undefined === username) {
             return null;
@@ -539,7 +540,7 @@ var KatanaCalDAVAdapter = DS.Adapter.extend({
                                     'HTTP/1.1 200 OK' === response.propStat[0].status) {
                                     var properties = response.propStat[0].prop;
 
-                                    if (type !== properties['{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set'].children[0].attributes['{}name']) {
+                                    if (TYPE !== properties['{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set'].children[0].attributes['{}name']) {
                                         return;
                                     }
 


### PR DESCRIPTION
Fix #199.

We use the `type` variable bellow in the code and we need it to be in lower case, so we create a new `TYPE` variable, containing the upper case version of the type, and use it only when needed.