### PR TITLE
Add instructions for DAV clients

### DIFF
--- a/public/static/javascript/admin.js
+++ b/public/static/javascript/admin.js
@@ -809,7 +809,32 @@ Katana._DavListController = Ember.Controller.extend({
     /**
      * Owner of the DAV list (aka. calendars, address books or task lists).
      */
-    currentUser : null
+    currentUser     : null,
+
+    /**
+     * Whether instructions should be shown or not.
+     */
+    showInstructions: false,
+
+    actions: {
+
+        /**
+         * Request to show instructions.
+         */
+        requestInstructions: function()
+        {
+            this.set('showInstructions', true);
+        },
+
+        /**
+         * Do not show instructions.
+         */
+        cancelInstructions: function()
+        {
+            this.set('showInstructions', false);
+        }
+
+    }
 
 });
 

--- a/public/static/javascript/admin.js
+++ b/public/static/javascript/admin.js
@@ -21,7 +21,8 @@
 var ENV = ENV || {};
 
 ENV['katana'] = {
-    base_url: window.location.pathname.replace(/\/+[^\/]*$/, '/') + 'server.php'
+    origin_url: window.location.origin,
+    base_url  : window.location.pathname.replace(/\/+[^\/]*$/, '/') + 'server.php/'
 };
 ENV['simple-auth'] = {
     // Declare our custom authorizer.
@@ -99,7 +100,7 @@ Katana.CustomAuthenticator = SimpleAuth.Authenticators.Base.extend({
             function(resolve, reject) {
                 Ember.$.ajax({
                     method : 'PROPFIND',
-                    url    : ENV.katana.base_url + '/versions',
+                    url    : ENV.katana.base_url + 'versions',
                     headers: {
                         'Authorization': 'Basic ' + basic,
                         'Content-Type' : 'application/xml; charset=utf-8'
@@ -394,7 +395,7 @@ Katana.ApplicationController = Ember.Controller.extend(SimpleAuth.Authentication
     {
         var self = this;
 
-        $.getJSON(ENV.katana.base_url + '/versions').then(
+        $.getJSON(ENV.katana.base_url + 'versions').then(
             function(data) {
                 self.set('newVersionAvailable', undefined !== data.next_versions);
             }

--- a/public/static/javascript/katana-webdav-adapter.js
+++ b/public/static/javascript/katana-webdav-adapter.js
@@ -33,17 +33,17 @@ var KatanaWebDAV = {
 
     getPrincipalsURL: function()
     {
-        return ENV.katana.base_url + '/principals/';
+        return ENV.katana.base_url + 'principals/';
     },
 
     getCalendarsURL: function()
     {
-        return ENV.katana.base_url + '/calendars/';
+        return ENV.katana.base_url + 'calendars/';
     },
 
     getAddressBooksURL: function()
     {
-        return ENV.katana.base_url + '/addressbooks/';
+        return ENV.katana.base_url + 'addressbooks/';
     },
 
     xhr: function(method, url, headers, body)

--- a/views/admin.html
+++ b/views/admin.html
@@ -340,6 +340,27 @@
       <p>No calendar yet.</p>
     {{/each}}
   {{/calendar-list}}
+
+  {{#if showInstructions}}
+    <div class="ui info message">
+      <i {{action 'cancelInstructions'}} class="close icon"></i>
+      <div class="header">Client instructions</div>
+      <p>In the client application, register a new <strong>CalDAV
+      account</strong> or a new <strong>calendar</strong> with the following
+      information in manual mode:</p>
+      <ul>
+        <li>Username: <code>{{currentUser}}</code>,</li>
+        <li>Password: <em>user's password</em>,</li>
+        <li>Server address: <code>{{ENV.katana.origin_url}}{{ENV.katana.base_url}}</code>.</li>
+      </ul>
+      <p>Ensure that the “Calendars” option is selected.</p>
+    </div>
+  {{else}}
+    <div {{action 'requestInstructions'}} class="ui tiny fluid icon button" style="margin-top: 1em">
+      Show client instructions
+      <i class="chevron down icon"></i>
+    </div>
+  {{/if}}
 </script>
 
 <script type="text/x-handlebars" id="users/user/addressBooks">
@@ -357,6 +378,26 @@
       <p>No address book yet.</p>
     {{/each}}
   {{/address-book-list}}
+
+  {{#if showInstructions}}
+    <div class="ui info message">
+      <i {{action 'cancelInstructions'}} class="close icon"></i>
+      <div class="header">Client instructions</div>
+      <p>In the client application, register a new <strong>CardDAV
+      account</strong> or a new <strong>address book</strong> with the following
+      information in manual mode:</p>
+      <ul>
+        <li>Username: <code>{{currentUser}}</code>,</li>
+        <li>Password: <em>user's password</em>,</li>
+        <li>Server address: <code>{{ENV.katana.origin_url}}{{ENV.katana.base_url}}</code>.</li>
+      </ul>
+    </div>
+  {{else}}
+    <div {{action 'requestInstructions'}} class="ui tiny fluid icon button" style="margin-top: 1em">
+      Show client instructions
+      <i class="chevron down icon"></i>
+    </div>
+  {{/if}}
 </script>
 
 <script type="text/x-handlebars" id="users/user/tasks">
@@ -375,6 +416,27 @@
       <p>No task list yet.</p>
     {{/each}}
   {{/calendar-list}}
+
+  {{#if showInstructions}}
+    <div class="ui info message">
+      <i {{action 'cancelInstructions'}} class="close icon"></i>
+      <div class="header">Client instructions</div>
+      <p>In the client application, register a new <strong>CalDAV
+      account</strong> or a new <strong>task list</strong> with the following
+      information in manual mode:</p>
+      <ul>
+        <li>Username: <code>{{currentUser}}</code>,</li>
+        <li>Password: <em>user's password</em>,</li>
+        <li>Server address: <code>{{ENV.katana.origin_url}}{{ENV.katana.base_url}}</code>.</li>
+      </ul>
+      <p>Ensure that the “Task lists” or “Reminders” option is selected.</p>
+    </div>
+  {{else}}
+    <div {{action 'requestInstructions'}} class="ui tiny fluid icon button" style="margin-top: 1em">
+      Show client instructions
+      <i class="chevron down icon"></i>
+    </div>
+  {{/if}}
 </script>
 
 <script type="text/x-handlebars" id="about">

--- a/views/admin.html
+++ b/views/admin.html
@@ -345,7 +345,7 @@
     <div class="ui info message">
       <i {{action 'cancelInstructions'}} class="close icon"></i>
       <div class="header">Client instructions</div>
-      <p>In the client application, register a new <strong>CalDAV
+      <p>In the client application, create a new <strong>CalDAV
       account</strong> or a new <strong>calendar</strong> with the following
       information in manual mode:</p>
       <ul>
@@ -353,7 +353,7 @@
         <li>Password: <em>user's password</em>,</li>
         <li>Server address: <code>{{ENV.katana.origin_url}}{{ENV.katana.base_url}}</code>.</li>
       </ul>
-      <p>Ensure that the “Calendars” option is selected.</p>
+      <p>Make sure that the “Calendars” option is selected.</p>
     </div>
   {{else}}
     <div {{action 'requestInstructions'}} class="ui tiny fluid icon button" style="margin-top: 1em">
@@ -383,7 +383,7 @@
     <div class="ui info message">
       <i {{action 'cancelInstructions'}} class="close icon"></i>
       <div class="header">Client instructions</div>
-      <p>In the client application, register a new <strong>CardDAV
+      <p>In the client application, create a new <strong>CardDAV
       account</strong> or a new <strong>address book</strong> with the following
       information in manual mode:</p>
       <ul>
@@ -421,7 +421,7 @@
     <div class="ui info message">
       <i {{action 'cancelInstructions'}} class="close icon"></i>
       <div class="header">Client instructions</div>
-      <p>In the client application, register a new <strong>CalDAV
+      <p>In the client application, create a new <strong>CalDAV
       account</strong> or a new <strong>task list</strong> with the following
       information in manual mode:</p>
       <ul>
@@ -429,7 +429,7 @@
         <li>Password: <em>user's password</em>,</li>
         <li>Server address: <code>{{ENV.katana.origin_url}}{{ENV.katana.base_url}}</code>.</li>
       </ul>
-      <p>Ensure that the “Task lists” or “Reminders” option is selected.</p>
+      <p>Make sure that the “Task lists” or “Reminders” option is selected.</p>
     </div>
   {{else}}
     <div {{action 'requestInstructions'}} class="ui tiny fluid icon button" style="margin-top: 1em">


### PR DESCRIPTION
Fix #170.

Show instructions for DAV clients to use Katana.

Here are the screenshots.

Button, to request instructions:
![screen shot 2015-05-12 at 17 15 40](https://cloud.githubusercontent.com/assets/946104/7590904/fe72af80-f8ca-11e4-954d-ff3dea3bf273.png)

Calendars instructions opened:
![screen shot 2015-05-12 at 17 15 43](https://cloud.githubusercontent.com/assets/946104/7590906/099651e6-f8cb-11e4-9d2a-42a977bb30ca.png)

Address books instructions opened:
![screen shot 2015-05-12 at 17 15 53](https://cloud.githubusercontent.com/assets/946104/7590914/0fb25278-f8cb-11e4-89b2-02146e10725f.png)

Task lists instructions opened:
![screen shot 2015-05-12 at 17 16 03](https://cloud.githubusercontent.com/assets/946104/7590921/17645b9c-f8cb-11e4-8cd6-ad85b5c645f6.png)