### PR TITLE
Print previous exception if exists.

### DIFF
--- a/lib/Bin/Install.php
+++ b/lib/Bin/Install.php
@@ -500,6 +500,15 @@ class Install extends AbstractCommand {
         } catch (\Exception $e) {
 
             $progress(-1, 'An error occured: ' . $e->getMessage());
+
+            if (null !== $previous = $e->getPrevious()) {
+                echo 'Underlying error: ' . $previous->getMessage();
+            }
+
+            echo "\n",
+                 'You are probably likely to run: ' .
+                 '`make uninstall` before trying again.', "\n";
+
             return 2;
 
         }

--- a/public/install.php
+++ b/public/install.php
@@ -66,7 +66,7 @@ if (true === Installer::isDirectoryEmpty('katana://public/static/vendor/')) {
 /**
  * If the application has not the correct permissions.
  */
-$view = function ($directoryName, $directory) {
+$view = function($directoryName, $directory) {
     $user        = get_current_user();
     $userId      = getmyuid();
     $groupId     = getmygid();


### PR DESCRIPTION
Fix #218.

With this PR:
```
Choose the base URL [default: /]:
Your administrator login: admin
Choose the administrator password:
Choose the administrator email: a@a.com
Choose the database driver (sqlite or mysql) [default: sqlite]: mysql
Choose MySQL host: 127.0.0.1
Choose MySQL port [default: 3306]:
Choose MySQL database name: katana
Choose MySQL username: root
Choose MySQL password:

Ready to install? (Enter to continue, Ctrl-C to abort)


Create configuration file…
Configuration file created 👍!
Create the database…
An error occured: Cannot create the database.
Underlying error: SQLSTATE[42000] [1049] Unknown database 'katana'
You are probably likely to run: `make uninstall` before trying again.
```

Check the “An error occured” and “Underlying error” lines.