### PR TITLE
Make `build-moment` re-runable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ build-semantic-ui:
 		public/static/vendor/semantic-ui
 
 build-moment:
-	mkdir public/static/vendor/moment/
-	mv \
+	mkdir -p public/static/vendor/moment/
+	cp \
 		node_modules/moment/min/moment.min.js \
 		public/static/vendor/moment/
 


### PR DESCRIPTION
First we run `mkdir` with the `-p` option to avoid an error if the directory already exists.
Second we copy and no longer move the `moment.min.js` file.