### PR TITLE
`public/` directory for homes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -725,7 +725,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/d7ea90a7511390d34872caf38662fb356616ede9",
+                "url": "https://api.github.com/repos/fruux/sabre-dav/zipball/172bed634122f547e014dc1326cf0b8f562b1705",
                 "reference": "d7ea90a7511390d34872caf38662fb356616ede9",
                 "shasum": ""
             },
@@ -1747,12 +1747,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruux/sabre-cs.git",
-                "reference": "e0af0f030abc125199114c0a3ed99164c6949aba"
+                "reference": "144f364e076b42ac856970809aaec45bde4d2295"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-cs/zipball/e0af0f030abc125199114c0a3ed99164c6949aba",
-                "reference": "e0af0f030abc125199114c0a3ed99164c6949aba",
+                "url": "https://api.github.com/repos/fruux/sabre-cs/zipball/144f364e076b42ac856970809aaec45bde4d2295",
+                "reference": "144f364e076b42ac856970809aaec45bde4d2295",
                 "shasum": ""
             },
             "require": {
@@ -1802,7 +1802,7 @@
                 "cs",
                 "sabre"
             ],
-            "time": "2015-05-07 09:04:10"
+            "time": "2015-05-19 14:11:33"
         },
         {
             "name": "sebastian/diff",

--- a/lib/DavAcl/File/Directory.php
+++ b/lib/DavAcl/File/Directory.php
@@ -24,7 +24,6 @@ namespace Sabre\Katana\DavAcl\File;
 use Sabre\DAVACL as SabreDavAcl;
 use Sabre\DAV as SabreDav;
 use Sabre\Uri as SabreUri;
-use Hoa\File as HoaFile;
 
 /**
  * This class represents a directory inside the home collection.
@@ -71,7 +70,7 @@ class Directory extends SabreDavAcl\FS\Collection {
 
             $acl = $this->acl;
 
-            if(true === $this->isPublic()) {
+            if (true === $this->isPublic()) {
                 $acl = [
                     [
                         'privilege' => '{DAV:}read',

--- a/lib/DavAcl/File/Directory.php
+++ b/lib/DavAcl/File/Directory.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * @license
+ *
+ * sabre/katana.
+ * Copyright (C) 2015 fruux GmbH (https://fruux.com/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Sabre\Katana\DavAcl\File;
+
+use Sabre\DAVACL as SabreDavAcl;
+use Sabre\DAV as SabreDav;
+use Hoa\File as HoaFile;
+
+/**
+ * This class represents a directory inside the home collection.
+ * We automatically re-create and set specific ACL to the `public/` directory.
+ *
+ * @copyright Copyright (C) 2015 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license GNU Affero General Public License, Version 3.
+ */
+class Directory extends SabreDavAcl\FS\Collection {
+
+    /**
+     * Relative path, aka storage path of the home directory.
+     *
+     * @var string
+     */
+    protected static $relativePath = null;
+
+    /**
+     * Returns a specific child node, referenced by its name
+     *
+     * This method must throw Sabre\DAV\Exception\NotFound if the node does not
+     * exist.
+     *
+     * @param string $name
+     * @throws DAV\Exception\NotFound
+     * @return DAV\INode
+     */
+    function getChild($name) {
+
+        $path = $this->path . DS . $name;
+
+        if (!file_exists($path)) {
+            throw new SabreDav\Exception\NotFound('File could not be located');
+        }
+
+        if ('.' === $name || '..' === $name) {
+            throw new SabreDav\Exception\Forbidden('Permission denied to . and ..');
+        }
+
+        if (is_dir($path)) {
+            $acl = $this->acl;
+
+            if (true === $this->isRoot() && 'public' === $name) {
+                $acl = [
+                    [
+                        'privilege' => '{DAV:}read',
+                        'principal' => '{DAV:}all',
+                        'protected' => true
+                    ],
+                    [
+                        'privilege' => '{DAV:}write',
+                        'principal' => $this->owner,
+                        'protected' => true
+                    ]
+                ];
+            }
+
+            return new self($path, $acl, $this->owner);
+        } else {
+            return new SabreDavAcl\FS\File($path, $this->acl, $this->owner);
+        }
+    }
+
+    /**
+     * Set relative path.
+     *
+     * @param  string  $relativePath    Relative path.
+     * @return void
+     */
+    function setRelativePath($relativePath) {
+
+        self::$relativePath = $relativePath;
+    }
+
+    /**
+     * Get relative path.
+     *
+     * @return string
+     */
+    static function getRelativePath() {
+
+        return self::$relativePath;
+    }
+
+    /**
+     * Check if the current directory is root from the principal point of view.
+     * It means, `<principal>/files/` is considered as the root.
+     *
+     * @return bool
+     */
+    function isRoot() {
+
+        $simplifiedPath = substr(
+            $this->path,
+            strlen($this->getRelativePath())
+        );
+
+        return '.' === dirname(trim($simplifiedPath, '/\\'));
+    }
+}

--- a/lib/DavAcl/File/Home.php
+++ b/lib/DavAcl/File/Home.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @license
+ *
+ * sabre/katana.
+ * Copyright (C) 2015 fruux GmbH (https://fruux.com/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Sabre\Katana\DavAcl\File;
+
+use Sabre\DAVACL as SabreDavAcl;
+use Sabre\Uri;
+use Hoa\File as HoaFile;
+
+/**
+ * This class represents a collection of home directories. A home directory is a
+ * principal specific WebDAV folder. Only the owner can read and write inside
+ * this folder, except for the `public/` directory where everyone can read.
+ *
+ * @copyright Copyright (C) 2015 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license GNU Affero General Public License, Version 3.
+ */
+class Home extends SabreDavAcl\FS\HomeCollection {
+
+    /**
+     * Returns a principals' collection of files.
+     *
+     * The passed array contains principal information, and is guaranteed to
+     * at least contain a uri item. Other properties may or may not be
+     * supplied by the authentication backend.
+     *
+     * @param array $principalInfo
+     * @return void
+     */
+    function getChildForPrincipal(array $principalInfo) {
+
+        $owner = $principalInfo['uri'];
+        $acl   = [
+            [
+                'privilege' => '{DAV:}read',
+                'principal' => $owner,
+                'protected' => true,
+            ],
+            [
+                'privilege' => '{DAV:}write',
+                'principal' => $owner,
+                'protected' => true,
+            ],
+        ];
+
+        list(, $principalBaseName) = Uri\split($owner);
+
+        $path = $this->storagePath . DS . $principalBaseName;
+
+        if (!is_dir($path)) {
+            HoaFile\Directory::create(
+                $path,
+                HoaFile\Directory::MODE_CREATE_RECURSIVE
+            );
+        }
+
+        $public = $path . DS . 'public';
+
+        if (!is_dir($public)) {
+            HoaFile\Directory::create(
+                $public,
+                HoaFile\Directory::MODE_CREATE_RECURSIVE
+            );
+        }
+
+        $out = new Directory($path, $acl, $owner);
+        $out->setRelativePath($this->storagePath);
+
+        return $out;
+    }
+}

--- a/lib/DavAcl/File/Home.php
+++ b/lib/DavAcl/File/Home.php
@@ -22,7 +22,7 @@
 namespace Sabre\Katana\DavAcl\File;
 
 use Sabre\DAVACL as SabreDavAcl;
-use Sabre\Uri;
+use Sabre\Uri as SabreUri;
 use Hoa\File as HoaFile;
 
 /**
@@ -62,7 +62,7 @@ class Home extends SabreDavAcl\FS\HomeCollection {
             ],
         ];
 
-        list(, $principalBaseName) = Uri\split($owner);
+        list(, $principalBaseName) = SabreUri\split($owner);
 
         $path = $this->storagePath . DS . $principalBaseName;
 

--- a/lib/DavAcl/User/Plugin.php
+++ b/lib/DavAcl/User/Plugin.php
@@ -32,6 +32,7 @@ use Sabre\DAV as SabreDav;
  * @license GNU Affero General Public License, Version 3.
  */
 class Plugin extends SabreDav\ServerPlugin {
+
     /**
      * DAV server.
      *

--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -228,9 +228,10 @@ class Server {
      */
     protected function initializeWebDAV(DavAcl\Principal\Backend $principalBackend) {
 
-        $collection = new SabreDavAcl\FS\HomeCollection(
+        $collection = new DavAcl\File\Home(
             $principalBackend,
-            Protocol::realPath('katana://data/home/')
+            Protocol::realPath('katana://data/home/'),
+            'principals'
         );
         $collection->collectionName = 'files';
         $this->getServer()->tree->getNodeForPath('')->addChild($collection);

--- a/public/static/javascript/admin.js
+++ b/public/static/javascript/admin.js
@@ -1241,7 +1241,14 @@ Katana.File = DS.Model.extend(KatanaValidatorMixin, {
     lastModifiedForHuman: function()
     {
         return moment(this.get('lastModified')).calendar();
-    }.property('lastModifiedForHuman')
+    }.property('lastModifiedForHuman'),
+
+    fileURL: function()
+    {
+        return KatanaWebDAV.getFilesURL() +
+               this.get('user').get('username') +
+               this.get('pathname');
+    }.property('fileURL')
 
 });
 

--- a/views/admin.html
+++ b/views/admin.html
@@ -192,7 +192,7 @@
     {{#link-to 'users.user.tasks' class="item"}}
       <i class="tasks icon"></i> Task lists
     {{/link-to}}
-    {{#link-to 'users.user.files' class="item"}}
+    {{#link-to 'users.user.files' (query-params directory='/') class="item"}}
       <i class="folder open outline icon"></i> Files
     {{/link-to}}
   </nav>

--- a/views/admin.html
+++ b/views/admin.html
@@ -468,6 +468,7 @@
           <th>Filename</th>
           <th>Size</th>
           <th>Last modified</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -499,6 +500,11 @@
             </td>
             <td>
               {{item.lastModifiedForHuman}}
+            </td>
+            <td>
+              <a {{bind-attr href=item.fileURL download=item.filename}} title="Download this file" class="ui right floated icon button">
+                <i class="cloud download icon"></i>
+              </a>
             </td>
           </tr>
         {{else}}


### PR DESCRIPTION
Fix #230.

Progression:
* [x] Automatically create the `public/` directory,
* [x] Automatically re-create the `public/` directory (if deleted),
* [x] Specific ACL for the `public/` directory,
* [x] Disable listing,
* [ ] Tests.