### PR TITLE
Print an error message if prior versions of IE9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ to create an executable PHAR archive.
 ## Supported technologies
 
 So far, sabre/katana can be installed with [SQLite] or [MySQL]. It works in all
-major browsers, except IE9 (we are working on it).
+major browsers, except prior versions of IE9.
 
 ## Build status
 

--- a/public/static/css/layout.css
+++ b/public/static/css/layout.css
@@ -2,6 +2,14 @@
     font-size: 1em;
 }
 
+.when-bad-browser {
+    display: none;
+}
+
+html.bad-browser .when-bad-browser {
+    display: inline;
+}
+
 header {
     padding-top: 1em;
     margin-bottom: 3em;

--- a/resource/view/admin.html
+++ b/resource/view/admin.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 
+<!--[if lt IE 9]><html lang="en" class="bad-browser"><![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!-->
 <html lang="en">
+<!--<![endif]-->
 <head>
   <title>Administration of sabre/katana</title>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -14,6 +17,15 @@
   <link rel="stylesheet" href="static/css/ui.css" type="text/css" />
 </head>
 <body>
+
+<div class="when-bad-browser">
+  <p style="color: #fff; text-align: center; padding: 2em; background: #f00">
+    <strong style="display: block">You are apparently using a prior version of
+    Internet Explorer 9.</strong>
+    We cannot guarantee sabre/katana to work safely and properly. We advice you
+    to update your browser or to download another more recent one.
+  </p>
+</div>
 
 <script type="text/x-handlebars">
   {{#if session.isAuthenticated}}

--- a/resource/view/install.html
+++ b/resource/view/install.html
@@ -2,7 +2,10 @@
 
 <!DOCTYPE html>
 
+<!--[if lt IE 9]><html lang="en" class="bad-browser"><![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!-->
 <html lang="en">
+<!--<![endif]-->
 <head>
   <title>Installation of sabre/katana</title>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
@@ -16,6 +19,15 @@
   <link rel="stylesheet" href="static/css/ui.css" type="text/css" />
 </head>
 <body>
+
+<div class="when-bad-browser">
+  <p style="color: #fff; text-align: center; padding: 2em; background: #f00">
+    <strong style="display: block">You are apparently using a prior version of
+    Internet Explorer 9.</strong>
+    We cannot guarantee sabre/katana to work safely and properly. We advice you
+    to update your browser or to download another more recent one.
+  </p>
+</div>
 
 <script type="text/x-handlebars">
   <header>


### PR DESCRIPTION
Fix #145.

So far, it is possible to detect if Semantic UI, Ember or jQuery are supported by the browser. So we assume these projects have good tests (for features and supports) and we only detect if the user is running a prior version of IE9. If it does, then we print a big red message.