### PR TITLE
Prevent query parameters to be corrupted

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -247,6 +247,11 @@ if (false !== $pos = strpos($url, '?')) {
         );
 
     $query = substr($url, $pos + 1);
+
+    if (false !== $posEnd = strpos($query, '&')) {
+        $query = substr($query, 0, $posEnd);
+    }
+
     $router->route($query, '/');
 
     $dispatcher = new Dispatcher\Basic();


### PR DESCRIPTION
Fix #271.

This situation should not happen but some browsers (Google Chrome 42.0 for instance) adds random query parameters. This patch cleans the query string.